### PR TITLE
fix MoonPhaseFinderTest. SimpleDateFormat use Locale.ENGLISH

### DIFF
--- a/src/test/java/com/bradsbrain/simpleastronomy/MoonPhaseFinderTest.java
+++ b/src/test/java/com/bradsbrain/simpleastronomy/MoonPhaseFinderTest.java
@@ -134,7 +134,7 @@ public class MoonPhaseFinderTest {
 	
 	@Test
 	public void exampleFromDocumentation() {
-		DateFormat formatter = new SimpleDateFormat("MMM dd HH:mm:ss zzz yyyy");
+		DateFormat formatter = new SimpleDateFormat("MMM dd HH:mm:ss zzz yyyy",Locale.ENGLISH);
 		formatter.setTimeZone(chicagoTimeZone);
 		
 		Calendar cal = Calendar.getInstance(chicagoTimeZone);
@@ -147,7 +147,7 @@ public class MoonPhaseFinderTest {
 	
 	@Test
 	public void mebourneFullMoonMay2015() {
-		DateFormat formatter = new SimpleDateFormat("MMM dd HH:mm:ss zzz yyyy");
+		DateFormat formatter = new SimpleDateFormat("MMM dd HH:mm:ss zzz yyyy",Locale.ENGLISH);
 		formatter.setTimeZone(melbourneTimeZone);
 		
 		Calendar cal = Calendar.getInstance(melbourneTimeZone);
@@ -161,7 +161,7 @@ public class MoonPhaseFinderTest {
 
 	@Test
 	public void mebourneFullMoonDec2015() {
-		DateFormat formatter = new SimpleDateFormat("MMM dd HH:mm:ss zzz yyyy");
+		DateFormat formatter = new SimpleDateFormat("MMM dd HH:mm:ss zzz yyyy",Locale.ENGLISH);
 		formatter.setTimeZone(melbourneTimeZone);
 		
 		Calendar cal = Calendar.getInstance(melbourneTimeZone);


### PR DESCRIPTION
java.lang.AssertionError: 
Expected: is "Jun 15 15:25:00 CDT 2011"
     got: "июн 15 15:25:00 CDT 2011"

	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:21)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:8)
	at com.bradsbrain.simpleastronomy.MoonPhaseFinderTest.exampleFromDocumentation(MoonPhaseFinderTest.java:145)

if  default language isn't English, the tests do not pass